### PR TITLE
Fix copyright typo

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -1,4 +1,4 @@
-Copyright (c) Microsoft Corporation
+Copyright (c) 2019 MVExtensions Group
 
 All rights reserved.
  


### PR DESCRIPTION
This should be (c) MVExtensions group, not Microsoft?