### PR TITLE
Add license text to fix warnings in "npm install"

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,7 @@
   "description": "MV Basic",
   "version": "2.0.1",
   "publisher": "mvextensions",
+  "license": "MIT",
   "icon": "images/mvbasic-logo.png",
   "preview": false,
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "MV Basic",
   "version": "2.0.1",
   "publisher": "mvextensions",
+  "license": "MIT",
   "icon": "images/mvbasic-logo.png",
   "preview": false,
   "keywords": [

--- a/server/package.json
+++ b/server/package.json
@@ -4,6 +4,7 @@
   "description": "MV Basic",
   "version": "2.0.1",
   "publisher": "mvextensions",
+  "license": "MIT",
   "icon": "images/mvbasic-logo.png",
   "preview": true,
   "keywords": [
@@ -20,7 +21,6 @@
     "UniData",
     "UniVerse"
   ],
-  "license": "MIT",
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
A small fix to get rid of the warning during "npm install" about missing license fields.