### PR TITLE
Fix unresolved folder, other issues.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,9 +45,24 @@
        "runtimeExecutable": "${execPath}",
        "args": [
          "--extensionDevelopmentPath=${workspaceFolder}",
-         "D:/projects/mvbasic/accuterm-mvsvr-restfs/sample.code-workspace"
+         "C:/projects/mvbasic/accuterm-mvsvr-restfs/sample.code-workspace"
        ],
        "outFiles": ["${workspaceFolder}/client/out/test/**/*.js"]
+     }
+     ,
+     {
+       "name": "Gateway Test",
+       "type": "extensionHost",
+       "request": "launch",
+       "runtimeExecutable": "${execPath}",
+       "stopOnEntry": false,
+       "sourceMaps": true,
+       "outFiles": ["${workspaceFolder}/client/out/**/*.js"],
+        "args": [
+         "--extensionDevelopmentPath=${workspaceFolder}",
+         "C:/projects/mvbasic/jbase-gateway.code-workspace"
+       ],
+       "preLaunchTask": "npm: watch"
      }
   ],
   "compounds": [

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -182,6 +182,7 @@
 		},
 		"block-stream": {
 			"version": "0.0.9",
+			"resolved": false,
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"requires": {
 				"inherits": "~2.0.0"
@@ -1223,6 +1224,7 @@
 		},
 		"inherits": {
 			"version": "2.0.3",
+			"resolved": false,
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"is": {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -39,6 +39,7 @@ var RestAPIVersion: number;
 var RestMaxItems: number;
 var RestSelAttr: number;
 var RestCaseSensitive: boolean;
+var logLevel: string;
 
 export function activate(context: ExtensionContext) {
 
@@ -96,8 +97,13 @@ export function activate(context: ExtensionContext) {
 		RestMaxItems = vscode.workspace.getConfiguration("MVBasic").get("RestFS.MaxItems", 0);
 		RestSelAttr = vscode.workspace.getConfiguration("MVBasic").get("RestFS.SelAttr", 0);
 		RestCaseSensitive = vscode.workspace.getConfiguration("MVBasic").get("RestFS.CaseSensitive");
+		logLevel = vscode.workspace.getConfiguration("MVBasic").get("trace.server", "off");
 		// gateway implies RestFS
 		UsingRest = UsingRest || UseGateway;
+		if (UsingRest && RESTFS) {
+			RESTFS.max_items = RestMaxItems;
+			RESTFS.sel_attr = RestSelAttr;			
+		}
 	}
 
 	// Reload the config if changes are made
@@ -141,7 +147,7 @@ export function activate(context: ExtensionContext) {
 		const connectRestFS = async function (): Promise<boolean> {
 
 			try {
-				RESTFS.initRestFS(RestPath, Account, { case_insensitive: !RestCaseSensitive, max_items: RestMaxItems, sel_attr: RestSelAttr });
+				RESTFS.initRestFS(RestPath, Account, { case_insensitive: !RestCaseSensitive, max_items: RestMaxItems, sel_attr: RestSelAttr, log_level: logLevel });
 
 				// send credentials (some of these are specific to the gateway)
 				const login = {
@@ -195,7 +201,7 @@ export function activate(context: ExtensionContext) {
 				vscode.workspace.getConfiguration("MVBasic").update("RestPath", RestPath, false);
 			}
 			if (RestPath === "") {
-				vscode.window.showInformationMessage('Please configure the RESTFul Path in the workspace settings.');
+				vscode.window.showInformationMessage('Please configure the RestPath in the workspace settings.');
 				return;
 			}
 			connectRestFS();

--- a/package.json
+++ b/package.json
@@ -261,7 +261,8 @@
         "MVBasic.RestFS.AutoConnect": {
           "scope": "resource",
           "type": "boolean",
-          "default": "Automatically connect to the RestFS server without requiring a Connect command."
+          "default": false,
+          "description": "Automatically connect to the RestFS server without requiring a Connect command."
         },
         "MVBasic.RestFS.CaseSensitive": {
           "scope": "resource",


### PR DESCRIPTION
Added verbose MV Basic RestFS output channel, enabled by MVBasic.trace.server workspace setting. Show error message for "too many items" which causes unresolved workspace folder.