### PR TITLE
Issue 82: Do not add spaces/indentation to blank lines

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -102,7 +102,7 @@ export function activate(context: ExtensionContext) {
 		UsingRest = UsingRest || UseGateway;
 		if (UsingRest && RESTFS) {
 			RESTFS.max_items = RestMaxItems;
-			RESTFS.sel_attr = RestSelAttr;			
+			RESTFS.sel_attr = RestSelAttr;
 		}
 	}
 
@@ -243,7 +243,7 @@ export function activate(context: ExtensionContext) {
 	});
 
 
-	// Push the disposable to the context's subscriptions so that the 
+	// Push the disposable to the context's subscriptions so that the
 	// client can be deactivated on extension deactivation
 	context.subscriptions.push(mvonAdmin);
 	context.subscriptions.push(disposable);
@@ -367,7 +367,9 @@ export function activate(context: ExtensionContext) {
 					// ignore labels
 					if (rLabel.test(line.text.trim()) == true) { continue }
 
-
+					// ignore blank lines or lines that only contain spaces
+					var blankLine = line.text.replace(/\s/g, "")
+					if (blankLine.length == 0) { continue }
 
 					var indentation = 0
 
@@ -383,7 +385,7 @@ export function activate(context: ExtensionContext) {
 					if (new RegExp("(^end else$)", "i").test(line.text.trim()) == true) {
 						indentation -= indent
 					}
-					if (indentation < 0 || formattingEnabled) {
+					if (indentation < 1) {
 						edits.push(vscode.TextEdit.replace(line.range, line.text.trim()))
 					}
 					else {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -367,10 +367,6 @@ export function activate(context: ExtensionContext) {
 					// ignore labels
 					if (rLabel.test(line.text.trim()) == true) { continue }
 
-					// ignore blank lines or lines that only contain spaces
-					var blankLine = line.text.replace(/\s/g, "")
-					if (blankLine.length == 0) { continue }
-
 					var indentation = 0
 
 					if (RowLevel[i] === undefined) { continue; }
@@ -385,7 +381,9 @@ export function activate(context: ExtensionContext) {
 					if (new RegExp("(^end else$)", "i").test(line.text.trim()) == true) {
 						indentation -= indent
 					}
-					if (indentation < 1) {
+
+					var blankLine = line.text.replace(/\s/g, "")
+					if (indentation < 1 || blankLine.length == 0) {
 						edits.push(vscode.TextEdit.replace(line.range, line.text.trim()))
 					}
 					else {


### PR DESCRIPTION
This change prevents the formatting process from adding spaces to blank lines.  This restores the formatting behaviour of previous versions.

This all seems to work as expected on my system, but having not contributed to VS Code extensions before now, this PR should be reviewed and tested before merging.