### PR TITLE
Fixed duplicate auto-suggest labels for GO/GOSUB/GO TO/GOTO IntelliSense Statements

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -947,17 +947,18 @@ connection.onCompletion(
             statement.toLocaleLowerCase() === "goto"
           ) {
             for (let i = 0; i < LabelList.length; i++) {
-              Intellisense.push({
-                label: LabelList[i].LabelName,
-                kind: CompletionItemKind.Reference,
-                data: 999
-              });
+              if (!Intellisense.some(statementLabel => statementLabel['label'] === LabelList[i].LabelName)) {
+                Intellisense.push({
+                  label: LabelList[i].LabelName,
+                  kind: CompletionItemKind.Reference,
+                  data: 999
+                });
+              }
             }
           }
         }
       }
     }
-
     return Intellisense;
   }
 );


### PR DESCRIPTION
The issue was that every label would be added without checking if it already existed within the `Intellisense` object. It now will check if the label exists in the `Intellisense` object before adding it.

Issue: #127 